### PR TITLE
feat: add robust PDF parsing

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -12,7 +12,8 @@
     "@db/sqlite": "jsr:@db/sqlite@0.12.0",
     "@std/path": "jsr:@std/path@1.1.2",
     "@std/fs": "jsr:@std/fs@1.0.19",
-    "@std/http": "jsr:@std/http@1.0.20"
+    "@std/http": "jsr:@std/http@1.0.20",
+    "pdf-parse": "npm:pdf-parse@^1.1.1"
   },
   "compilerOptions": {
     "lib": ["deno.window"],

--- a/src-deno/core/file_processor.ts
+++ b/src-deno/core/file_processor.ts
@@ -1,12 +1,9 @@
 // src-deno/core/file_processor.ts
-import { FileService } from "../services/file_service.ts";
-import { KnowledgeService } from "../services/knowledge_service.ts";
 import { LLMFactory } from "../lib/llm_factory.ts";
 import { emitEventToFrontend } from "../tauri_bridge.ts";
 import { QdrantClient } from "../db/qdrant_client.ts";
 import { SettingsService } from "../services/settings_service.ts";
 import { FileStorageClient } from "../db/file_storage_client.ts";
-import { SecretsService } from "../services/secrets_service.ts";
 import { parsePdfContent } from "../lib/pdf/pdf_parser.ts";
 
 // Text splitter implementation
@@ -15,17 +12,26 @@ class RecursiveCharacterTextSplitter {
   private chunkOverlap: number;
   private separators: string[];
 
-  constructor(options: { chunkSize?: number; chunkOverlap?: number; separators?: string[] }) {
+  constructor(
+    options: {
+      chunkSize?: number;
+      chunkOverlap?: number;
+      separators?: string[];
+    },
+  ) {
     this.chunkSize = options.chunkSize || 1000;
     this.chunkOverlap = options.chunkOverlap || 200;
     this.separators = options.separators || ["\n\n", "\n", " ", ""];
   }
 
-  async splitText(text: string): Promise<string[]> {
+  splitText(text: string): Promise<string[]> {
     return this.splitTextRecursive(text, this.separators);
   }
 
-  private async splitTextRecursive(text: string, separators: string[]): Promise<string[]> {
+  private async splitTextRecursive(
+    text: string,
+    separators: string[],
+  ): Promise<string[]> {
     // If text is short enough, return as is
     if (text.length <= this.chunkSize) {
       return [text];
@@ -47,7 +53,9 @@ class RecursiveCharacterTextSplitter {
     let currentChunk = "";
 
     for (const split of splits) {
-      const prospectiveChunk = currentChunk ? currentChunk + separator + split : split;
+      const prospectiveChunk = currentChunk
+        ? currentChunk + separator + split
+        : split;
 
       if (prospectiveChunk.length > this.chunkSize) {
         // If we have a current chunk, add it to final chunks
@@ -59,7 +67,7 @@ class RecursiveCharacterTextSplitter {
         if (prospectiveChunk.length > this.chunkSize) {
           const recursiveChunks = await this.splitTextRecursive(
             prospectiveChunk,
-            separators.slice(1)
+            separators.slice(1),
           );
           finalChunks.push(...recursiveChunks);
           currentChunk = "";
@@ -97,15 +105,16 @@ class RecursiveCharacterTextSplitter {
 
       // Find a good overlap point (try to break at sentence or word boundaries)
       let overlapPoint = Math.min(this.chunkOverlap, prevChunk.length);
-      
+
       // Try to find a better overlap point at a sentence or word boundary
       for (let j = 0; j < this.separators.length; j++) {
         const sep = this.separators[j];
         const lastPart = prevChunk.slice(-overlapPoint);
         const lastSepIndex = lastPart.lastIndexOf(sep);
-        
+
         if (lastSepIndex > 0) {
-          overlapPoint = overlapPoint - lastPart.length + lastSepIndex + sep.length;
+          overlapPoint = overlapPoint - lastPart.length + lastSepIndex +
+            sep.length;
           break;
         }
       }
@@ -120,15 +129,17 @@ class RecursiveCharacterTextSplitter {
 
 // Progress tracking for file processing
 interface ProcessingProgress {
-  status: 'PROCESSING' | 'INDEXING' | 'COMPLETED' | 'ERROR';
+  status: "PROCESSING" | "INDEXING" | "COMPLETED" | "ERROR";
   progress: number;
   message: string;
 }
 
 export async function processAndEmbedFile(fileId: string, kbId: string) {
   const startTime = Date.now();
-  console.log(`Starting file processing for file ${fileId} in knowledge base ${kbId}`);
-  
+  console.log(
+    `Starting file processing for file ${fileId} in knowledge base ${kbId}`,
+  );
+
   try {
     // 1. Get file and knowledge base info from storage
     const fileStorage = FileStorageClient.getInstance();
@@ -136,167 +147,245 @@ export async function processAndEmbedFile(fileId: string, kbId: string) {
     if (!file) {
       throw new Error(`File with ID ${fileId} not found`);
     }
-    
+
     const kb = await fileStorage.getKnowledgeBase(kbId);
     if (!kb) {
       throw new Error(`Knowledge base with ID ${kbId} not found`);
     }
-    
+
     console.log(`Processing file: ${file.name} (${file.mimeType})`);
-    
+
     // Update file status
-    await fileStorage.updateFileStatus(fileId, 'PROCESSING');
-    emitProgressUpdate(fileId, { status: 'PROCESSING', progress: 0, message: 'Processing file...' });
+    await fileStorage.updateFileStatus(fileId, "PROCESSING");
+    emitProgressUpdate(fileId, {
+      status: "PROCESSING",
+      progress: 0,
+      message: "Processing file...",
+    });
 
     // 2. Read file content
     let text: string;
-    if (file.mimeType === 'application/pdf') {
-      emitProgressUpdate(fileId, { status: 'PROCESSING', progress: 10, message: 'Parsing PDF content...' });
+    if (file.mimeType === "application/pdf") {
+      emitProgressUpdate(fileId, {
+        status: "PROCESSING",
+        progress: 10,
+        message: "Parsing PDF content...",
+      });
       console.log("Parsing PDF content...");
+      const filePath = file.path;
       try {
-        text = await parsePdfContent(file.path);
-        console.log(`PDF parsing completed, extracted ${text.length} characters`);
-      } catch (pdfError: any) {
-        console.error("Error parsing PDF:", pdfError);
-        throw new Error(`Failed to parse PDF file: ${pdfError.message}`);
+        text = await parsePdfContent(filePath);
+        console.log(
+          `PDF parsing completed, extracted ${text.length} characters`,
+        );
+      } catch (pdfError: unknown) {
+        console.error(`Error parsing PDF at ${filePath}:`, pdfError);
+        const message = pdfError instanceof Error
+          ? pdfError.message
+          : String(pdfError);
+        throw new Error(`Failed to parse PDF file at ${filePath}: ${message}`);
       }
     } else {
       // For text files, read directly
-      emitProgressUpdate(fileId, { status: 'PROCESSING', progress: 10, message: 'Reading text content...' });
+      emitProgressUpdate(fileId, {
+        status: "PROCESSING",
+        progress: 10,
+        message: "Reading text content...",
+      });
       console.log("Reading text content...");
       try {
         const fileData = await Deno.readTextFile(file.path);
         text = fileData;
-        console.log(`Text reading completed, extracted ${text.length} characters`);
-      } catch (readError: any) {
+        console.log(
+          `Text reading completed, extracted ${text.length} characters`,
+        );
+      } catch (readError: unknown) {
         console.error("Error reading text file:", readError);
-        throw new Error(`Failed to read text file: ${readError.message}`);
+        const message = readError instanceof Error
+          ? readError.message
+          : String(readError);
+        throw new Error(`Failed to read text file: ${message}`);
       }
     }
 
     // 3. Split text into manageable chunks
-    emitProgressUpdate(fileId, { status: 'PROCESSING', progress: 30, message: 'Splitting text into chunks...' });
+    emitProgressUpdate(fileId, {
+      status: "PROCESSING",
+      progress: 30,
+      message: "Splitting text into chunks...",
+    });
     console.log("Splitting text into chunks...");
-    const textSplitter = new RecursiveCharacterTextSplitter({ 
-      chunkSize: 1000, 
-      chunkOverlap: 200 
+    const textSplitter = new RecursiveCharacterTextSplitter({
+      chunkSize: 1000,
+      chunkOverlap: 200,
     });
     const chunks = await textSplitter.splitText(text);
-    
+
     if (chunks.length === 0) {
       throw new Error("No text content found in file");
     }
-    
+
     console.log(`Text splitting completed, created ${chunks.length} chunks`);
 
     // 4. Generate embeddings for chunks
-    emitProgressUpdate(fileId, { status: 'INDEXING', progress: 50, message: `Generating embeddings for ${chunks.length} chunks...` });
-    console.log(`Generating embeddings for ${chunks.length} chunks using model: ${kb.embeddingModel}`);
-    
+    emitProgressUpdate(fileId, {
+      status: "INDEXING",
+      progress: 50,
+      message: `Generating embeddings for ${chunks.length} chunks...`,
+    });
+    console.log(
+      `Generating embeddings for ${chunks.length} chunks using model: ${kb.embeddingModel}`,
+    );
+
     // Use the LLM factory to get the appropriate client based on the embedding model
     const llmClient = await LLMFactory.getClientForModel(kb.embeddingModel);
-    
+
     // Generate embeddings in batches to avoid rate limits
     const batchSize = 10;
     const embeddings: number[][] = [];
-    
+
     for (let i = 0; i < chunks.length; i += batchSize) {
       const batch = chunks.slice(i, i + batchSize);
-      console.log(`Generating embeddings for batch ${Math.floor(i/batchSize) + 1} of ${Math.ceil(chunks.length/batchSize)}`);
-      
+      console.log(
+        `Generating embeddings for batch ${Math.floor(i / batchSize) + 1} of ${
+          Math.ceil(chunks.length / batchSize)
+        }`,
+      );
+
       try {
-        const batchEmbeddings = await llmClient.generateEmbeddings(batch, kb.embeddingModel);
+        const batchEmbeddings = await llmClient.generateEmbeddings(
+          batch,
+          kb.embeddingModel,
+        );
         embeddings.push(...batchEmbeddings);
-      } catch (embeddingError: any) {
-        console.error(`Error generating embeddings for batch ${Math.floor(i/batchSize) + 1}:`, embeddingError);
-        throw new Error(`Failed to generate embeddings: ${embeddingError.message}`);
+      } catch (embeddingError: unknown) {
+        console.error(
+          `Error generating embeddings for batch ${
+            Math.floor(i / batchSize) + 1
+          }:`,
+          embeddingError,
+        );
+        const message = embeddingError instanceof Error
+          ? embeddingError.message
+          : String(embeddingError);
+        throw new Error(`Failed to generate embeddings: ${message}`);
       }
-      
+
       // Update progress
       const progress = 50 + Math.floor((i / chunks.length) * 30);
-      emitProgressUpdate(fileId, { 
-        status: 'INDEXING', 
-        progress, 
-        message: `Generated embeddings for ${Math.min(i + batchSize, chunks.length)} of ${chunks.length} chunks...` 
+      emitProgressUpdate(fileId, {
+        status: "INDEXING",
+        progress,
+        message: `Generated embeddings for ${
+          Math.min(i + batchSize, chunks.length)
+        } of ${chunks.length} chunks...`,
       });
-      
+
       // Small delay between batches to avoid rate limits
-      await new Promise(resolve => setTimeout(resolve, 50));
+      await new Promise((resolve) => setTimeout(resolve, 50));
     }
-    
-    console.log(`Embedding generation completed for all ${chunks.length} chunks`);
+
+    console.log(
+      `Embedding generation completed for all ${chunks.length} chunks`,
+    );
 
     // 5. Format data for Qdrant and upsert
-    emitProgressUpdate(fileId, { status: 'INDEXING', progress: 80, message: 'Preparing data for vector database...' });
+    emitProgressUpdate(fileId, {
+      status: "INDEXING",
+      progress: 80,
+      message: "Preparing data for vector database...",
+    });
     console.log("Preparing data for vector database...");
-    
+
     const points = chunks.map((chunk, index) => ({
       id: crypto.randomUUID(), // Qdrant point ID
       vector: embeddings[index],
-      payload: { 
-        content: chunk, 
-        file_id: fileId, 
-        file_name: file.name, 
-        chunk_index: index 
-      }
+      payload: {
+        content: chunk,
+        file_id: fileId,
+        file_name: file.name,
+        chunk_index: index,
+      },
     }));
-    
+
     console.log(`Prepared ${points.length} points for vector database`);
-    
+
     // Get Qdrant configuration from settings
     const settings = await SettingsService.getAppSettings();
     const qdrantClient = new QdrantClient(
-      settings.qdrantUrl, 
-      settings.qdrantApiKey || ""
+      settings.qdrantUrl,
+      settings.qdrantApiKey || "",
     );
-    
+
     // Ensure the collection exists
     const collectionName = `knowledge_base_${kbId}`;
-    const collectionExists = await qdrantClient.collectionExists(collectionName);
+    const collectionExists = await qdrantClient.collectionExists(
+      collectionName,
+    );
     if (!collectionExists) {
       console.log(`Creating Qdrant collection: ${collectionName}`);
       await qdrantClient.createCollection(collectionName, kb.vectorSize);
     }
-    
+
     // Upsert points to Qdrant
-    emitProgressUpdate(fileId, { status: 'INDEXING', progress: 90, message: `Indexing ${points.length} chunks in vector database...` });
+    emitProgressUpdate(fileId, {
+      status: "INDEXING",
+      progress: 90,
+      message: `Indexing ${points.length} chunks in vector database...`,
+    });
     console.log(`Indexing ${points.length} chunks in vector database...`);
     try {
       await qdrantClient.upsertPoints(collectionName, points);
-    } catch (qdrantError: any) {
+    } catch (qdrantError: unknown) {
       console.error("Error upserting points to Qdrant:", qdrantError);
-      throw new Error(`Failed to index chunks in vector database: ${qdrantError.message}`);
+      const message = qdrantError instanceof Error
+        ? qdrantError.message
+        : String(qdrantError);
+      throw new Error(`Failed to index chunks in vector database: ${message}`);
     }
 
     // 6. Finalize status
-    await fileStorage.updateFileStatus(fileId, 'INDEXED');
-    emitProgressUpdate(fileId, { status: 'COMPLETED', progress: 100, message: 'File processing completed successfully!' });
-    
+    await fileStorage.updateFileStatus(fileId, "INDEXED");
+    emitProgressUpdate(fileId, {
+      status: "COMPLETED",
+      progress: 100,
+      message: "File processing completed successfully!",
+    });
+
     const totalTime = Date.now() - startTime;
-    console.log(`File processing completed for ${fileId} in knowledge base ${kbId} in ${totalTime}ms`);
+    console.log(
+      `File processing completed for ${fileId} in knowledge base ${kbId} in ${totalTime}ms`,
+    );
   } catch (error) {
     const totalTime = Date.now() - startTime;
-    console.error(`Error processing file (completed in ${totalTime}ms):`, error);
-    
+    console.error(
+      `Error processing file (completed in ${totalTime}ms):`,
+      error,
+    );
+
     // Update status to error
     try {
       const fileStorage = FileStorageClient.getInstance();
-      await fileStorage.updateFileStatus(fileId, 'ERROR');
-      emitProgressUpdate(fileId, { status: 'ERROR', progress: 0, message: `Error: ${(error as Error).message}` });
-    } catch (statusError: any) {
+      await fileStorage.updateFileStatus(fileId, "ERROR");
+      emitProgressUpdate(fileId, {
+        status: "ERROR",
+        progress: 0,
+        message: `Error: ${(error as Error).message}`,
+      });
+    } catch (statusError: unknown) {
       console.error("Failed to update file status to ERROR:", statusError);
     }
-    
+
     throw error;
   }
 }
 
 // Helper function to emit progress updates
 function emitProgressUpdate(fileId: string, progress: ProcessingProgress) {
-  emitEventToFrontend('file-processing-progress', { 
-    fileId, 
+  emitEventToFrontend("file-processing-progress", {
+    fileId,
     status: progress.status,
     progress: progress.progress,
-    message: progress.message
+    message: progress.message,
   });
 }

--- a/src-deno/lib/pdf/pdf_parser.ts
+++ b/src-deno/lib/pdf/pdf_parser.ts
@@ -1,111 +1,26 @@
 // src-deno/lib/pdf/pdf_parser.ts
-// Enhanced PDF text extraction using a more robust approach
+// PDF text extraction using a library for improved reliability
+
+import pdfParse from "pdf-parse";
+import { Buffer } from "node:buffer";
 
 export async function parsePdfContent(filePath: string): Promise<string> {
   try {
     // Read the PDF file as binary data
-    const pdfData = await Deno.readFile(filePath);
-    
-    // Convert to string for processing
-    const pdfText = new TextDecoder().decode(pdfData);
-    
-    // Enhanced text extraction that handles more PDF formats
-    let extractedText = "";
-    
-    // Method 1: Extract text between parentheses (basic PDF text format)
-    const textMatches = pdfText.match(/\([^)]+\)/g);
-    if (textMatches && textMatches.length > 0) {
-      // Clean up the extracted text
-      const method1Text = textMatches
-        .map(match => match.slice(1, -1)) // Remove parentheses
-        .map(text => text.replace(/\\n/g, " ")) // Replace escaped newlines
-        .map(text => text.replace(/\\t/g, " ")) // Replace escaped tabs
-        .map(text => text.replace(/\\r/g, " ")) // Replace escaped carriage returns
-        .map(text => text.replace(/\\(.)/g, "$1")) // Handle other escaped characters
-        .join(" ");
-      
-      extractedText += method1Text + " ";
+    const data = await Deno.readFile(filePath);
+    const buffer = Buffer.from(data);
+
+    // Use the pdf-parse library to extract text
+    const result = (await pdfParse(buffer)) as { text: string };
+
+    if (!result.text) {
+      throw new Error("No text found in PDF");
     }
-    
-    // Method 2: Extract text between BT and ET markers (begin/end text)
-    const btEtSections = pdfText.match(/BT[\s\S]*?ET/g);
-    if (btEtSections && btEtSections.length > 0) {
-      // Extract text between parentheses within BT/ET blocks
-      const method2Text = btEtSections
-        .map(block => {
-          const textMatches = block.match(/\([^)]+\)/g);
-          return textMatches ? textMatches.map(match => match.slice(1, -1)).join(" ") : "";
-        })
-        .filter(text => text.length > 0)
-        .join(" ");
-      
-      extractedText += method2Text + " ";
-    }
-    
-    // Method 3: Extract text from Tf (text font) commands
-    const tfSections = pdfText.match(/Tf[\s\S]*?Tj/g);
-    if (tfSections && tfSections.length > 0) {
-      // Extract text between parentheses in Tf sections
-      const method3Text = tfSections
-        .map(section => {
-          const textMatches = section.match(/\([^)]+\)/g);
-          return textMatches ? textMatches.map(match => match.slice(1, -1)).join(" ") : "";
-        })
-        .filter(text => text.length > 0)
-        .join(" ");
-      
-      extractedText += method3Text + " ";
-    }
-    
-    // Method 4: Extract content from content streams
-    const contentStreams = pdfText.match(/\/Contents\s+[\d\s]+R[\s\S]*?stream[\s\S]*?endstream/g);
-    if (contentStreams && contentStreams.length > 0) {
-      const method4Text = contentStreams
-        .map(stream => {
-          // Extract text between parentheses in content streams
-          const textMatches = stream.match(/\([^)]+\)/g);
-          return textMatches ? textMatches.map(match => match.slice(1, -1)).join(" ") : "";
-        })
-        .filter(text => text.length > 0)
-        .join(" ");
-      
-      extractedText += method4Text + " ";
-    }
-    
-    // If we couldn't extract text using the above methods, try a fallback approach
-    if (!extractedText.trim()) {
-      // Remove binary data and extract readable text
-      let cleanText = pdfText;
-      
-      // Remove stream objects that contain binary data
-      cleanText = cleanText.replace(/stream[\s\S]*?endstream/g, "");
-      
-      // Remove xref and trailer sections
-      cleanText = cleanText.replace(/xref[\s\S]*?trailer/g, "");
-      cleanText = cleanText.replace(/startxref[\s\S]*?%%EOF/g, "");
-      
-      // Remove object definitions
-      cleanText = cleanText.replace(/[\d\s]+obj[\s\S]*?endobj/g, "");
-      
-      // Extract sequences of readable characters
-      const readableMatches = cleanText.match(/[a-zA-Z0-9\s\.\,\!\?\;\:]+/g);
-      if (readableMatches) {
-        extractedText = readableMatches.join(" ");
-      } else {
-        // Final fallback: keep only alphanumeric and basic punctuation
-        extractedText = cleanText
-          .replace(/[^a-zA-Z0-9\s\.\,\!\?\;\:]/g, " ")
-          .replace(/\s+/g, " ")
-          .trim();
-      }
-    }
-    
-    // Clean up the final text
-    return extractedText
-      .replace(/\s+/g, " ") // Normalize whitespace
-      .trim();
-  } catch (error: any) {
+
+    return result.text.trim();
+  } catch (error: unknown) {
     console.error("Error parsing PDF content:", error);
-    throw new Error(`Failed to parse PDF file: ${error.message}`);
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to parse PDF file: ${message}`);
   }
 }


### PR DESCRIPTION
## Summary
- use pdf-parse to extract text from PDFs
- forward file paths to the parser and surface errors with more detail
- register pdf-parse in Deno import map

## Testing
- `deno lint src-deno/lib/pdf/pdf_parser.ts src-deno/core/file_processor.ts`
- `deno check src-deno/lib/pdf/pdf_parser.ts`  
- `deno check src-deno/core/file_processor.ts` *(fails: JSR package manifest for '@openai/openai' failed to load)*
- `deno task test` *(fails: invalid peer certificate when fetching std dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68a5f298edc483328da0db7beaa0e489