### PR TITLE
feat: add qdrant connection testing and data path selection

### DIFF
--- a/src-deno/api/settings.ts
+++ b/src-deno/api/settings.ts
@@ -30,7 +30,8 @@ export interface AppSettings {
   qdrantUrl: string;
   qdrantApiKey?: string;
   dataDirectory: string;
-  
+  sqlitePath?: string;
+
   // MCP settings
   mcpServers: MCPServer[];
 }

--- a/src-deno/db/schema.ts
+++ b/src-deno/db/schema.ts
@@ -100,7 +100,8 @@ export interface AppSettings {
   qdrantUrl: string;
   qdrantApiKey?: string;
   dataDirectory: string;
-  
+  sqlitePath?: string;
+
   // MCP settings
   mcpServers: MCPServer[];
 }

--- a/src-deno/main.ts
+++ b/src-deno/main.ts
@@ -42,6 +42,7 @@ export interface AppSettings {
   qdrantUrl: string;
   qdrantApiKey?: string;
   dataDirectory: string;
+  sqlitePath?: string;
 
   // MCP settings
   mcpServers: MCPServer[];

--- a/src-deno/services/settings_service.ts
+++ b/src-deno/services/settings_service.ts
@@ -41,7 +41,8 @@ export class SettingsService {
       qdrantUrl: settingsRecord?.qdrantUrl || "http://localhost:6333",
       qdrantApiKey: settingsRecord?.qdrantApiKey,
       dataDirectory: settingsRecord?.dataDirectory || path.join(Deno.cwd(), "data"),
-      
+      sqlitePath: settingsRecord?.sqlitePath,
+
       // MCP settings
       mcpServers: settingsRecord?.mcpServers ? JSON.parse(settingsRecord.mcpServers) : [
         { id: 1, name: "Local Ollama", url: "http://localhost:11434", enabled: true }
@@ -77,6 +78,7 @@ export class SettingsService {
     if (settings.googleCseId) settingsRecord.googleCseId = settings.googleCseId;
     if (settings.serpApiKey) settingsRecord.serpApiKey = settings.serpApiKey;
     if (settings.qdrantApiKey) settingsRecord.qdrantApiKey = settings.qdrantApiKey;
+    if (settings.sqlitePath) settingsRecord.sqlitePath = settings.sqlitePath;
     
     const fileStorage = FileStorageClient.getInstance();
     await fileStorage.updateAppSettings(settingsRecord);

--- a/src-tauri/main.rs
+++ b/src-tauri/main.rs
@@ -157,7 +157,7 @@ async fn test_qdrant_connection(
     qdrant_api_key: Option<&str>,
 ) -> Result<bool, String> {
     let client = reqwest::Client::new();
-    let url = format!("{}/collections", qdrant_url.trim_end_matches('/'));
+    let url = format!("{}/", qdrant_url.trim_end_matches('/'));
     let mut request = client.get(&url);
     if let Some(key) = qdrant_api_key {
         request = request.header("api-key", key);

--- a/src-tauri/main.rs
+++ b/src-tauri/main.rs
@@ -68,10 +68,13 @@ fn main() {
             update_assistant,
             delete_assistant,
             list_agents,
-            
+
             // Chat commands
             start_chat_session,
-            send_message
+            send_message,
+
+            // Qdrant commands
+            test_qdrant_connection
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
@@ -145,6 +148,24 @@ async fn set_secret(_key: &str, _value: &str) -> Result<(), String> {
     // For now, we'll just return Ok(()) since we're not implementing the stronghold integration fully
     // In a real implementation, you would use the stronghold API to store secrets
     Ok(())
+}
+
+// Qdrant commands
+#[tauri::command]
+async fn test_qdrant_connection(
+    qdrant_url: &str,
+    qdrant_api_key: Option<&str>,
+) -> Result<bool, String> {
+    let client = reqwest::Client::new();
+    let url = format!("{}/collections", qdrant_url.trim_end_matches('/'));
+    let mut request = client.get(&url);
+    if let Some(key) = qdrant_api_key {
+        request = request.header("api-key", key);
+    }
+    match request.send().await {
+        Ok(resp) => Ok(resp.status().is_success()),
+        Err(e) => Err(format!("Request failed: {}", e)),
+    }
 }
 
 // Files & Knowledge Bases commands

--- a/src-tauri/main.rs
+++ b/src-tauri/main.rs
@@ -164,7 +164,7 @@ async fn test_qdrant_connection(
     }
     match request.send().await {
         Ok(resp) => Ok(resp.status().is_success()),
-        Err(e) => Err(format!("Request failed: {}", e)),
+        Err(_) => Err("Failed to connect to Qdrant. Please check your URL and API key.".to_string()),
     }
 }
 

--- a/src/api/settings.ts
+++ b/src/api/settings.ts
@@ -21,6 +21,16 @@ export const setSecret = (key: string, value: string): Promise<void> => {
   return invoke('setSecret', { key, value });
 };
 
+export const testQdrantConnection = (
+  qdrantUrl: string,
+  qdrantApiKey?: string
+): Promise<boolean> => {
+  return invoke<boolean>('test_qdrant_connection', {
+    qdrantUrl,
+    qdrantApiKey,
+  });
+};
+
 // Provider-specific functions
 export const testProviderConnection = (providerId: string): Promise<boolean> => {
   return invoke<boolean>('testProviderConnection', { providerId });

--- a/src/features/settings/DataSettings.tsx
+++ b/src/features/settings/DataSettings.tsx
@@ -46,7 +46,6 @@ const DataSettings: React.FC = () => {
           dataDirectory,
           ...(databaseType === "sqlite" ? { sqlitePath } : {}),
         });
-      }
     } catch (error) {
       setConnectionStatus("error");
     } finally {

--- a/src/hooks/useTauriMutation.ts
+++ b/src/hooks/useTauriMutation.ts
@@ -112,6 +112,8 @@ async function mockMutation<T, V>(command: string, variables: T): Promise<V> {
         systemPrompt: (variables as any).config.systemPrompt || "You are a helpful assistant.",
         createdAt: new Date().toISOString()
       } as unknown as V;
+    case "test_qdrant_connection":
+      return { success: true } as unknown as V;
     default:
       return {} as unknown as V;
   }


### PR DESCRIPTION
## Summary
- add `test_qdrant_connection` backend command and wire frontend to use it
- allow selecting data directory or sqlite database via Tauri dialog
- persist updated data settings through `update_app_settings`

## Testing
- `npx eslint .` *(fails: ESLint couldn't find configuration file)*
- `npx tsc -p tsconfig.json --noEmit`
- `npm test` *(fails: deno: not found)*
- `cargo check` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a5fb587c2c8332bfc7e2eaa6a6852b