### PR TITLE
Add web search provider testing and settings

### DIFF
--- a/src-deno/main.ts
+++ b/src-deno/main.ts
@@ -7,6 +7,7 @@ import { AgentService } from "./services/agent_service.ts";
 import { ChatService } from "./services/chat_service.ts";
 import { SecretsService } from "./services/secrets_service.ts";
 import { ProviderService } from "./services/provider_service.ts";
+import { WebSearchService } from "./services/web_search_service.ts";
 import { initializeStorage } from "./init_storage.ts";
 import { register } from "@tauri-apps/api/core";
 
@@ -209,11 +210,16 @@ export function testMcpServerConnection(url: string) {
   return ProviderService.testMcpServerConnection(url);
 }
 
+export function testWebSearchProvider(provider: string) {
+  return WebSearchService.testProvider(provider);
+}
+
 const commands = {
   getAppSettings,
   updateAppSettings,
   getSecret,
   setSecret,
+  set_secret: setSecret,
   listFiles,
   uploadFile,
   deleteFile,
@@ -232,6 +238,8 @@ const commands = {
   listProviderModels,
   getProviderConfig,
   testMcpServerConnection,
+  testWebSearchProvider,
+  test_web_search_provider: testWebSearchProvider,
 };
 
 // Initialize and register commands

--- a/src-deno/services/web_search_service.ts
+++ b/src-deno/services/web_search_service.ts
@@ -65,7 +65,7 @@ export class WebSearchService {
             (await SecretsService.getSecret("brave_api_key"));
           if (!apiKey) return false;
           const resp = await fetch(
-            "https://api.search.brave.com/res/v1/web/search?q=test&count=1",
+            `https://api.search.brave.com/res/v1/web/search?q=${encodeURIComponent(HEALTH_CHECK_QUERY)}&count=1`,
             {
               headers: {
                 "Accept": "application/json",

--- a/src-deno/tauri_commands.ts
+++ b/src-deno/tauri_commands.ts
@@ -16,7 +16,8 @@ import {
   deleteAssistant,
   listAgents,
   startChatSession,
-  sendMessage
+  sendMessage,
+  testWebSearchProvider,
 } from "./main.ts";
 
 // Import provider and MCP command implementations
@@ -65,6 +66,7 @@ export {
   listAgents,
   startChatSession,
   sendMessage,
+  testWebSearchProvider,
   // Provider commands
   testProviderConnectionCommand as testProviderConnection,
   listProviderModelsCommand as listProviderModels,

--- a/src/api/settings.ts
+++ b/src/api/settings.ts
@@ -35,3 +35,7 @@ export const listProviderModels = (
 export const getProviderConfig = (providerId: string): Promise<any> => {
   return invoke<any>('getProviderConfig', { providerId });
 };
+
+export const testWebSearchProvider = (provider: string): Promise<boolean> => {
+  return invoke<boolean>('testWebSearchProvider', { provider });
+};

--- a/src/features/settings/WebSearchSettings.tsx
+++ b/src/features/settings/WebSearchSettings.tsx
@@ -1,5 +1,7 @@
 // src/features/settings/WebSearchSettings.tsx
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
+import { useTauriQuery } from "../../hooks/useTauriQuery";
+import { getAppSettings, updateAppSettings, setSecret, testWebSearchProvider } from "../../api/settings";
 
 interface WebSearchProvider {
   id: string;
@@ -14,6 +16,7 @@ const WebSearchSettings: React.FC = () => {
   const [googleApiKey, setGoogleApiKey] = useState("");
   const [googleCseId, setGoogleCseId] = useState("");
   const [serpApiKey, setSerpApiKey] = useState("");
+  const { data: settings } = useTauriQuery<Awaited<ReturnType<typeof getAppSettings>>>("get_app_settings");
   const [selectedProvider, setSelectedProvider] = useState("brave");
   const [isTesting, setIsTesting] = useState<string | null>(null);
   const [testResults, setTestResults] = useState<Record<string, "success" | "error" | null>>({});
@@ -40,16 +43,41 @@ const WebSearchSettings: React.FC = () => {
     }
   ];
 
+  useEffect(() => {
+    if (settings) {
+      setSelectedProvider(settings.defaultWebSearchProvider);
+    }
+  }, [settings]);
+
+  const handleProviderSelect = async (providerId: string) => {
+    setSelectedProvider(providerId);
+    if (settings) {
+      await updateAppSettings({ ...settings, defaultWebSearchProvider: providerId });
+    }
+  };
+
   const handleTestConnection = async (service: string) => {
     setIsTesting(service);
     setTestResults(prev => ({ ...prev, [service]: null }));
-    
+
     try {
-      // Simulate testing connection
-      await new Promise(resolve => setTimeout(resolve, 1500));
-      
-      // Randomly succeed or fail for demonstration
-      const success = Math.random() > 0.3;
+      // Save provided keys before testing
+      if (service === "brave" && braveApiKey) {
+        await setSecret("brave_api_key", braveApiKey);
+      }
+      if (service === "google") {
+        if (googleApiKey) {
+          await setSecret("google_api_key", googleApiKey);
+        }
+        if (googleCseId) {
+          await setSecret("google_cse_id", googleCseId);
+        }
+      }
+      if (service === "serp" && serpApiKey) {
+        await setSecret("serp_api_key", serpApiKey);
+      }
+
+      const success = await testWebSearchProvider(service);
       setTestResults(prev => ({ ...prev, [service]: success ? "success" : "error" }));
     } catch (error) {
       setTestResults(prev => ({ ...prev, [service]: "error" }));
@@ -68,7 +96,7 @@ const WebSearchSettings: React.FC = () => {
           {providers.map((provider) => (
             <button
               key={provider.id}
-              onClick={() => setSelectedProvider(provider.id)}
+              onClick={() => handleProviderSelect(provider.id)}
               className={`p-4 rounded-lg border-2 transition-colors ${
                 selectedProvider === provider.id
                   ? "border-blue-500 bg-blue-900 bg-opacity-30"


### PR DESCRIPTION
## Summary
- add backend support to test web search providers and expose commands for storing secrets
- allow selecting and persisting a default web search provider
- show real connection results for Brave, Google, and Serp in web search settings

## Testing
- `deno lint src-deno/main.ts src-deno/services/web_search_service.ts src-deno/tauri_commands.ts`
- `npx tsc -p tsconfig.frontend.json --noEmit` *(fails: provider_service.ts:1292 'catch' or 'finally' expected)*
- `npm test` *(fails: invalid peer certificate when fetching Deno std modules)*

------
https://chatgpt.com/codex/tasks/task_b_68a5fb58bab4833291d1a675d9cb3c70