### PR TITLE
Add provider and web search connection tests with UI feedback

### DIFF
--- a/src-deno/api/web_search_commands.ts
+++ b/src-deno/api/web_search_commands.ts
@@ -7,6 +7,12 @@ export async function testWebSearchConnectionCommand(provider: string): Promise<
     return { success };
   } catch (error) {
     console.error(`Error testing web search connection for ${provider}:`, error);
-    return { success: false };
+export async function testWebSearchConnectionCommand(provider: string): Promise<boolean> {
+  try {
+    const success = await testWebSearchConnection(provider);
+    return success;
+  } catch (error) {
+    console.error(`Error testing web search connection for ${provider}:`, error);
+    return false;
   }
 }

--- a/src-deno/api/web_search_commands.ts
+++ b/src-deno/api/web_search_commands.ts
@@ -1,0 +1,12 @@
+// src-deno/api/web_search_commands.ts
+import { testWebSearchConnection } from "../services/web_search_service.ts";
+
+export async function testWebSearchConnectionCommand(provider: string): Promise<{ success: boolean }> {
+  try {
+    const success = await testWebSearchConnection(provider);
+    return { success };
+  } catch (error) {
+    console.error(`Error testing web search connection for ${provider}:`, error);
+    return { success: false };
+  }
+}

--- a/src-deno/tauri_commands.ts
+++ b/src-deno/tauri_commands.ts
@@ -30,6 +30,7 @@ import {
   removeMcpServerCommand,
   testMcpServerConnectionCommand
 } from "./api/provider_commands.ts";
+import { testWebSearchConnectionCommand } from "./api/web_search_commands.ts";
 
 // Type exports
 export type { 
@@ -74,5 +75,7 @@ export {
   addMcpServerCommand as addMcpServer,
   updateMcpServerCommand as updateMcpServer,
   removeMcpServerCommand as removeMcpServer,
-  testMcpServerConnectionCommand as testMcpServerConnection
+  testMcpServerConnectionCommand as testMcpServerConnection,
+  // Web search commands
+  testWebSearchConnectionCommand as testWebSearchConnection
 };

--- a/src/api/providers.ts
+++ b/src/api/providers.ts
@@ -1,0 +1,21 @@
+// src/api/providers.ts
+import { invoke } from '@tauri-apps/api/core';
+import type { ModelInfo, ProviderConfig } from '@src-deno/services/provider_service.ts';
+
+export type { ModelInfo, ProviderConfig };
+
+export const testProviderConnection = (providerId: string): Promise<boolean> => {
+  return invoke<boolean>('testProviderConnection', { providerId });
+};
+
+export const listProviderModels = (
+  providerId: string,
+): Promise<ModelInfo[]> => {
+  return invoke<ModelInfo[]>('listProviderModels', { providerId });
+};
+
+export const getProviderConfig = (
+  providerId: string,
+): Promise<ProviderConfig | null> => {
+  return invoke<ProviderConfig | null>('getProviderConfig', { providerId });
+};

--- a/src/api/settings.ts
+++ b/src/api/settings.ts
@@ -1,9 +1,8 @@
 // src/api/settings.ts
 import { invoke } from '@tauri-apps/api/core';
 import type { AppSettings } from '@src-deno/main.ts';
-import type { ModelInfo } from '@src-deno/services/provider_service.ts';
 
-export type { AppSettings, ModelInfo };
+export type { AppSettings };
 
 export const getAppSettings = (): Promise<AppSettings> => {
   return invoke<AppSettings>('getAppSettings');
@@ -19,19 +18,4 @@ export const getSecret = (key: string): Promise<string | null> => {
 
 export const setSecret = (key: string, value: string): Promise<void> => {
   return invoke('setSecret', { key, value });
-};
-
-// Provider-specific functions
-export const testProviderConnection = (providerId: string): Promise<boolean> => {
-  return invoke<boolean>('testProviderConnection', { providerId });
-};
-
-export const listProviderModels = (
-  providerId: string
-): Promise<ModelInfo[]> => {
-  return invoke<ModelInfo[]>('listProviderModels', { providerId });
-};
-
-export const getProviderConfig = (providerId: string): Promise<any> => {
-  return invoke<any>('getProviderConfig', { providerId });
 };

--- a/src/api/web_search.ts
+++ b/src/api/web_search.ts
@@ -2,5 +2,5 @@
 import { invoke } from '@tauri-apps/api/core';
 
 export const testWebSearchConnection = (provider: string): Promise<boolean> => {
-  return invoke<boolean>('testWebSearchConnection', { provider });
+  return invoke<{ success: boolean }>('testWebSearchConnection', { provider }).then(res => res.success);
 };

--- a/src/api/web_search.ts
+++ b/src/api/web_search.ts
@@ -1,0 +1,6 @@
+// src/api/web_search.ts
+import { invoke } from '@tauri-apps/api/core';
+
+export const testWebSearchConnection = (provider: string): Promise<boolean> => {
+  return invoke<boolean>('testWebSearchConnection', { provider });
+};

--- a/src/components/TestStatus.tsx
+++ b/src/components/TestStatus.tsx
@@ -1,0 +1,31 @@
+// src/components/TestStatus.tsx
+import React from 'react';
+
+type Status = 'success' | 'error' | null;
+
+interface TestStatusProps {
+  status: Status;
+  successMessage?: string;
+  errorMessage?: string;
+}
+
+const TestStatus: React.FC<TestStatusProps> = ({
+  status,
+  successMessage = 'Connection successful!',
+  errorMessage = 'Connection failed.',
+}) => {
+  if (!status) return null;
+  return (
+    <div
+      className={`px-3 py-2 rounded text-sm ${
+        status === 'success'
+          ? 'bg-green-900 text-green-200'
+          : 'bg-red-900 text-red-200'
+      }`}
+    >
+      {status === 'success' ? successMessage : errorMessage}
+    </div>
+  );
+};
+
+export default TestStatus;

--- a/src/features/providers/ProviderSettings.tsx
+++ b/src/features/providers/ProviderSettings.tsx
@@ -2,7 +2,9 @@
 import React, { useState, useEffect } from "react";
 import { useTauriQuery } from "../../hooks/useTauriQuery";
 import { useTauriMutation } from "../../hooks/useTauriMutation";
-import { getAppSettings, setSecret, testProviderConnection, listProviderModels } from "../../api/settings";
+import { getAppSettings, setSecret } from "../../api/settings";
+import { testProviderConnection, listProviderModels } from "../../api/providers";
+import TestStatus from "../../components/TestStatus";
 
 interface Provider {
   id: string;
@@ -327,17 +329,7 @@ const ProviderSettings: React.FC = () => {
                 {isTesting ? "Testing..." : "Test Connection"}
               </button>
               
-              {testResult && (
-                <div className={`px-3 py-2 rounded text-sm ${
-                  testResult === "success" 
-                    ? "bg-green-900 text-green-200" 
-                    : "bg-red-900 text-red-200"
-                }`}>
-                  {testResult === "success" 
-                    ? "Connection successful!" 
-                    : "Connection failed."}
-                </div>
-              )}
+              <TestStatus status={testResult} />
             </div>
             
             {testResult === "success" && (

--- a/src/features/settings/ModelSettings.tsx
+++ b/src/features/settings/ModelSettings.tsx
@@ -2,7 +2,8 @@
 import React, { useState, useEffect } from "react";
 import { useTauriQuery } from "../../hooks/useTauriQuery";
 import { useTauriMutation } from "../../hooks/useTauriMutation";
-import { getAppSettings, updateAppSettings, listProviderModels } from "../../api/settings";
+import { getAppSettings, updateAppSettings } from "../../api/settings";
+import { listProviderModels } from "../../api/providers";
 
 interface ModelInfo {
   id: string;

--- a/src/features/settings/ProviderSettings.tsx
+++ b/src/features/settings/ProviderSettings.tsx
@@ -2,7 +2,9 @@
 import React, { useState, useEffect } from "react";
 import { useTauriQuery } from "../../hooks/useTauriQuery";
 import { useTauriMutation } from "../../hooks/useTauriMutation";
-import { getAppSettings, setSecret, testProviderConnection, listProviderModels } from "../../api/settings";
+import { getAppSettings, setSecret } from "../../api/settings";
+import { testProviderConnection, listProviderModels } from "../../api/providers";
+import TestStatus from "../../components/TestStatus";
 
 interface Provider {
   id: string;
@@ -327,17 +329,7 @@ const ProviderSettings: React.FC = () => {
                 {isTesting ? "Testing..." : "Test Connection"}
               </button>
               
-              {testResult && (
-                <div className={`px-3 py-2 rounded text-sm ${
-                  testResult === "success" 
-                    ? "bg-green-900 text-green-200" 
-                    : "bg-red-900 text-red-200"
-                }`}>
-                  {testResult === "success" 
-                    ? "Connection successful!" 
-                    : "Connection failed."}
-                </div>
-              )}
+              <TestStatus status={testResult} />
             </div>
             
             {testResult === "success" && (

--- a/src/features/settings/WebSearchSettings.tsx
+++ b/src/features/settings/WebSearchSettings.tsx
@@ -1,5 +1,7 @@
 // src/features/settings/WebSearchSettings.tsx
 import React, { useState } from "react";
+import { testWebSearchConnection } from "../../api/web_search";
+import TestStatus from "../../components/TestStatus";
 
 interface WebSearchProvider {
   id: string;
@@ -43,14 +45,13 @@ const WebSearchSettings: React.FC = () => {
   const handleTestConnection = async (service: string) => {
     setIsTesting(service);
     setTestResults(prev => ({ ...prev, [service]: null }));
-    
+
     try {
-      // Simulate testing connection
-      await new Promise(resolve => setTimeout(resolve, 1500));
-      
-      // Randomly succeed or fail for demonstration
-      const success = Math.random() > 0.3;
-      setTestResults(prev => ({ ...prev, [service]: success ? "success" : "error" }));
+      const success = await testWebSearchConnection(service);
+      setTestResults(prev => ({
+        ...prev,
+        [service]: success ? "success" : "error",
+      }));
     } catch (error) {
       setTestResults(prev => ({ ...prev, [service]: "error" }));
     } finally {
@@ -121,17 +122,7 @@ const WebSearchSettings: React.FC = () => {
               {isTesting === "brave" ? "Testing..." : "Test Connection"}
             </button>
             
-            {testResults.brave && (
-              <div className={`px-3 py-2 rounded text-sm ${
-                testResults.brave === "success" 
-                  ? "bg-green-900 text-green-200" 
-                  : "bg-red-900 text-red-200"
-              }`}>
-                {testResults.brave === "success" 
-                  ? "Connection successful!" 
-                  : "Connection failed."}
-              </div>
-            )}
+            <TestStatus status={testResults.brave} />
           </div>
         </div>
       )}
@@ -199,17 +190,7 @@ const WebSearchSettings: React.FC = () => {
               {isTesting === "google" ? "Testing..." : "Test Connection"}
             </button>
             
-            {testResults.google && (
-              <div className={`px-3 py-2 rounded text-sm ${
-                testResults.google === "success" 
-                  ? "bg-green-900 text-green-200" 
-                  : "bg-red-900 text-red-200"
-              }`}>
-                {testResults.google === "success" 
-                  ? "Connection successful!" 
-                  : "Connection failed."}
-              </div>
-            )}
+            <TestStatus status={testResults.google} />
           </div>
         </div>
       )}
@@ -253,17 +234,7 @@ const WebSearchSettings: React.FC = () => {
               {isTesting === "serp" ? "Testing..." : "Test Connection"}
             </button>
             
-            {testResults.serp && (
-              <div className={`px-3 py-2 rounded text-sm ${
-                testResults.serp === "success" 
-                  ? "bg-green-900 text-green-200" 
-                  : "bg-red-900 text-red-200"
-              }`}>
-                {testResults.serp === "success" 
-                  ? "Connection successful!" 
-                  : "Connection failed."}
-              </div>
-            )}
+            <TestStatus status={testResults.serp} />
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- add command wrappers for provider and web search connection tests
- expose new API wrappers and shared TestStatus component
- wire settings UI test buttons to backend and show results

## Testing
- `deno lint src-deno/services/provider_service.ts src-deno/services/web_search_service.ts src-deno/api/web_search_commands.ts src-deno/tauri_commands.ts` *(fails: Expression expected in provider_service.ts)*
- `deno lint src-deno/services/web_search_service.ts src-deno/api/web_search_commands.ts src-deno/tauri_commands.ts`
- `npx tsc --project tsconfig.frontend.json --noEmit` *(fails: Cannot find name 'jest')*

------
https://chatgpt.com/codex/tasks/task_b_68a5fb593a508332b0f94b03858d8b82