### PR TITLE
feat: support file uploads via tauri dialog

### DIFF
--- a/src-deno/services/file_service.ts
+++ b/src-deno/services/file_service.ts
@@ -35,7 +35,7 @@ export class FileService {
     // Determine MIME type using extension lookup
     const ext = path.extname(fileName).toLowerCase();
     const mimeType = lookup(ext) || "application/octet-stream";
-    if (!["text/plain", "application/pdf", "text/markdown"].includes(mimeType)) {
+    if (!ALLOWED_MIME_TYPES.includes(mimeType)) {
       throw new Error(`Unsupported file type: ${mimeType}`);
     }
     

--- a/src-deno/services/file_service.ts
+++ b/src-deno/services/file_service.ts
@@ -3,6 +3,7 @@ import { ManagedFile } from "../db/schema.ts";
 import { generateUUID } from "../util/uuid.ts";
 import { FileStorageClient } from "../db/file_storage_client.ts";
 import * as path from "@std/path";
+import { lookup } from "@std/media-types";
 import { SettingsService } from "./settings_service.ts";
 
 export class FileService {
@@ -31,14 +32,11 @@ export class FileService {
     const fileInfo = await Deno.stat(filePath);
     const fileSize = fileInfo.size;
     
-    // Determine MIME type
-    let mimeType = "application/octet-stream";
-    if (fileName.endsWith(".txt")) {
-      mimeType = "text/plain";
-    } else if (fileName.endsWith(".pdf")) {
-      mimeType = "application/pdf";
-    } else if (fileName.endsWith(".md")) {
-      mimeType = "text/markdown";
+    // Determine MIME type using extension lookup
+    const ext = path.extname(fileName).toLowerCase();
+    const mimeType = lookup(ext) || "application/octet-stream";
+    if (!["text/plain", "application/pdf", "text/markdown"].includes(mimeType)) {
+      throw new Error(`Unsupported file type: ${mimeType}`);
     }
     
     const file: ManagedFile = {

--- a/src/features/files/FileUpload.tsx
+++ b/src/features/files/FileUpload.tsx
@@ -1,5 +1,6 @@
 // src/features/files/FileUpload.tsx
 import React, { useState } from 'react';
+import { open } from '@tauri-apps/api/dialog';
 import { useTauriMutation } from '../../hooks/useTauriMutation';
 
 interface FileUploadProps {
@@ -8,7 +9,13 @@ interface FileUploadProps {
 
 const FileUpload: React.FC<FileUploadProps> = ({ onUploadSuccess }) => {
   const [isDragging, setIsDragging] = useState(false);
-  const [file, setFile] = useState<File | null>(null);
+  interface SelectedFile {
+    path: string;
+    name: string;
+    size?: number;
+  }
+
+  const [file, setFile] = useState<SelectedFile | null>(null);
   
   const uploadMutation = useTauriMutation('upload_file');
 
@@ -24,38 +31,42 @@ const FileUpload: React.FC<FileUploadProps> = ({ onUploadSuccess }) => {
   const handleDrop = (e: React.DragEvent) => {
     e.preventDefault();
     setIsDragging(false);
-    
+
     if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
-      setFile(e.dataTransfer.files[0]);
+      const dropped = e.dataTransfer.files[0] as unknown as { path?: string; name: string; size: number };
+      const filePath = dropped.path || dropped.name;
+      setFile({ path: filePath, name: dropped.name, size: dropped.size });
     }
   };
 
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target.files && e.target.files.length > 0) {
-      setFile(e.target.files[0]);
+  const handleSelectFile = async () => {
+    try {
+      const selected = await open({
+        multiple: false,
+        filters: [{ name: 'Documents', extensions: ['txt', 'pdf', 'md'] }]
+      });
+      if (typeof selected === 'string') {
+        const parts = selected.split(/\\|\//);
+        const name = parts[parts.length - 1];
+        setFile({ path: selected, name });
+      }
+    } catch (err) {
+      console.error('Error selecting file:', err);
     }
   };
 
   const handleUpload = async () => {
     if (!file) return;
-    
+
+    const ext = file.name.split('.').pop()?.toLowerCase();
+    if (!ext || !['txt', 'pdf', 'md'].includes(ext)) {
+      console.error('Unsupported file type:', ext);
+      return;
+    }
+
     try {
-      // In a production Tauri application, we would use:
-      // import { open } from '@tauri-apps/api/dialog';
-      // const selected = await open({
-      //   multiple: false,
-      //   filters: [{
-      //     name: 'Documents',
-      //     extensions: ['txt', 'pdf', 'md']
-      //   }]
-      // });
-      
-      // For development simulation, we'll create a temporary file reference
-      // In a real implementation, the file would be processed through Tauri's filesystem APIs
-      const tempFilePath = file.name; // This would be the actual file path in Tauri
-      
       uploadMutation.mutate(
-        { filePath: tempFilePath, fileName: file.name },
+        { filePath: file.path, fileName: file.name },
         {
           onSuccess: () => {
             setFile(null);
@@ -79,19 +90,13 @@ const FileUpload: React.FC<FileUploadProps> = ({ onUploadSuccess }) => {
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
-        onClick={() => document.getElementById('file-input')?.click()}
+        onClick={handleSelectFile}
       >
-        <input
-          id="file-input"
-          type="file"
-          className="hidden"
-          onChange={handleFileChange}
-        />
         
         {file ? (
           <div>
             <p className="text-lg font-medium">{file.name}</p>
-            <p className="text-gray-400">{(file.size / 1024).toFixed(2)} KB</p>
+            <p className="text-gray-400">{file.size ? `${(file.size / 1024).toFixed(2)} KB` : ''}</p>
           </div>
         ) : (
           <div>
@@ -99,6 +104,7 @@ const FileUpload: React.FC<FileUploadProps> = ({ onUploadSuccess }) => {
             <p className="text-gray-400 mb-4">or click to select a file</p>
             <button
               type="button"
+              onClick={handleSelectFile}
               className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
             >
               Select File

--- a/src/features/files/FileUpload.tsx
+++ b/src/features/files/FileUpload.tsx
@@ -35,7 +35,14 @@ const FileUpload: React.FC<FileUploadProps> = ({ onUploadSuccess }) => {
     if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
       const dropped = e.dataTransfer.files[0] as unknown as { path?: string; name: string; size: number };
       const filePath = dropped.path || dropped.name;
-      setFile({ path: filePath, name: dropped.name, size: dropped.size });
+      const dropped = e.dataTransfer.files[0];
+      if (isSelectedFileLike(dropped)) {
+        const filePath = dropped.path || dropped.name;
+        setFile({ path: filePath, name: dropped.name, size: dropped.size });
+      } else {
+        // fallback: use name and size, path may not be available
+        setFile({ path: dropped.name, name: dropped.name, size: dropped.size });
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- use Tauri dialog to pick files and send real paths when uploading
- copy uploaded files into app data dir with mime detection and allow deletion

## Testing
- `deno lint src-deno/services/file_service.ts`
- `npx eslint src/features/files/FileUpload.tsx` *(fails: ESLint couldn't find an eslint.config.(js|mjs|cjs) file)*
- `npx tsc -p tsconfig.frontend.json --noEmit` *(fails: src-deno/services/provider_service.ts(1292,2): error TS1472: 'catch' or 'finally' expected.)*
- `npx tsc -p tsconfig.backend.json --noEmit` *(fails: src-deno/services/provider_service.ts(1292,2): error TS1472: 'catch' or 'finally' expected.)*
- `npm test` *(fails: Import 'https://deno.land/std@0.177.0/testing/asserts.ts' failed - invalid peer certificate: UnknownIssuer)*

------
https://chatgpt.com/codex/tasks/task_b_68a5fb59c9e08332a6d1074da9f36ade